### PR TITLE
Helm: Use existing secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ sc.exe create SqlExporterSvc binPath= "%SQL_EXPORTER_PATH%\sql_exporter.exe --co
 `%SQL_EXPORTER_PATH%` is a path to the SQL Exporter binary executable. This document assumes that configuration files
 are in the same location.
 
+## Helm installation
+
+A Helm chart is available for SQL Exporter. It can be installed by running the following commands:
+
+**TL;DR**
+```shell
+helm repo add burningalchemist https://burningalchemist.github.io
+helm intall burningalchemist/sql-exporter
+```
+
+
 ## Configuration
 
 SQL Exporter is deployed alongside the DB server it collects metrics from. If both the exporter and the DB
@@ -251,7 +262,7 @@ the secret. Policy example:
       "Effect": "Allow",
       "Principal": {"AWS": "arn:aws:iam::123456789012:role/EC2RoleToAccessSecrets"},
       "Action": "secretsmanager:GetSecretValue",
-      "Resource": "*",
+      "Resource": "*"
     }
   ]
 }

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -26,7 +26,11 @@ spec:
       volumes:
         - name: sql-exporter
           secret:
+            {{- if .Values.existingSecret }}
+            secretName: {{ .Values.existingSecret }}
+            {{- else }}
             secretName: {{ include "sql-exporter.fullname" . }}
+            {{- end }}
         {{- if .Values.collectorFiles }}
         - name: sql-collector
           configMap:

--- a/helm/templates/secret.configuration.yaml
+++ b/helm/templates/secret.configuration.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret }}
 # ---------------------------------------------------------------------
 # -- This secret holds the config file of sql_exporter
 # ---------------------------------------------------------------------
@@ -11,3 +12,4 @@ type: Opaque
 stringData:
   sql_exporter.yml: |-
     {{- toYaml .Values.config | nindent 4 }} 
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -39,6 +39,12 @@ securityContext:
 serviceMonitor:
   enabled: true
   interval: 15s
+
+# ---------------------------------------------------------------------
+# -- Option to provide an existing secret with all the values from the config section
+# ---------------------------------------------------------------------
+existingSecret: {}
+
   # ---------------------------------------------------------------------
   # -- SQL exporter configuration
   # -- For a comprehensive and comprehensively documented configuration


### PR DESCRIPTION
This PR adds the possibility to use an existing kubernetes secret when installing sql-exporter with the helm chart.

Fixes: #396